### PR TITLE
Add sepolicy for Xiaomi motor HAL and xiaomi-motor binary

### DIFF
--- a/private/file_contexts
+++ b/private/file_contexts
@@ -293,6 +293,7 @@
 /system/bin/statsd               u:object_r:statsd_exec:s0
 /system/bin/bpfloader            u:object_r:bpfloader_exec:s0
 /system/bin/wait_for_keymaster   u:object_r:wait_for_keymaster_exec:s0
+/system/bin/xiaomi-motor         u:object_r:xiaomi_motor_exec:s0
 
 #############################
 # Vendor files

--- a/private/system_server.te
+++ b/private/system_server.te
@@ -199,6 +199,7 @@ hal_client_domain(system_server, hal_health)
 hal_client_domain(system_server, hal_ir)
 hal_client_domain(system_server, hal_light)
 hal_client_domain(system_server, hal_memtrack)
+hal_client_domain(system_server, hal_motor)
 hal_client_domain(system_server, hal_neuralnetworks)
 hal_client_domain(system_server, hal_oemlock)
 allow system_server hal_codec2_hwservice:hwservice_manager find;

--- a/public/attributes
+++ b/public/attributes
@@ -283,6 +283,7 @@ hal_attribute(keymaster);
 hal_attribute(light);
 hal_attribute(lowpan);
 hal_attribute(memtrack);
+hal_attribute(motor);
 hal_attribute(neuralnetworks);
 hal_attribute(nfc);
 hal_attribute(oemlock);

--- a/public/cameraserver.te
+++ b/public/cameraserver.te
@@ -30,6 +30,10 @@ allow cameraserver surfaceflinger_service:service_manager find;
 
 allow cameraserver hidl_token_hwservice:hwservice_manager find;
 
+# Allow cameraserver to call Xiaomi motor HAL
+allow cameraserver hal_motor_hwservice:hwservice_manager find;
+binder_call(cameraserver, hal_motor_default)
+
 ###
 ### neverallow rules
 ###

--- a/public/hal_motor.te
+++ b/public/hal_motor.te
@@ -1,0 +1,5 @@
+# HwBinder IPC from client to server
+binder_call(hal_motor_client, hal_motor_server)
+
+add_hwservice(hal_motor_server, hal_motor_hwservice)
+allow hal_motor_client hal_motor_hwservice:hwservice_manager find;

--- a/public/hal_motor_default.te
+++ b/public/hal_motor_default.te
@@ -1,0 +1,4 @@
+type hal_motor_default, domain;
+hal_server_domain(hal_motor_default, hal_motor)
+
+type hal_motor_default_exec, exec_type, vendor_file_type, file_type;

--- a/public/hwservice.te
+++ b/public/hwservice.te
@@ -29,6 +29,7 @@ type hal_keymaster_hwservice, hwservice_manager_type;
 type hal_light_hwservice, hwservice_manager_type;
 type hal_lowpan_hwservice, hwservice_manager_type;
 type hal_memtrack_hwservice, hwservice_manager_type;
+type hal_motor_hwservice, hwservice_manager_type;
 type hal_neuralnetworks_hwservice, hwservice_manager_type;
 type hal_nfc_hwservice, hwservice_manager_type;
 type hal_oemlock_hwservice, hwservice_manager_type;

--- a/public/init.te
+++ b/public/init.te
@@ -492,6 +492,11 @@ allow init vendor_shell_exec:file execute;
 allow init vold_metadata_file:dir create_dir_perms;
 allow init vold_metadata_file:file getattr;
 
+# Allow init to run xiaomi-motor
+allow init xiaomi_motor_exec:file rx_file_perms;
+allow init hal_motor_hwservice:hwservice_manager find;
+binder_call(init, hal_motor_default)
+
 ###
 ### neverallow rules
 ###

--- a/public/shell.te
+++ b/public/shell.te
@@ -199,6 +199,11 @@ allow shell sepolicy_file:file r_file_perms;
 # Allow shell to start up vendor shell
 allow shell vendor_shell_exec:file rx_file_perms;
 
+# Allow shell to run xiaomi-motor
+allow shell xiaomi_motor_exec:file rx_file_perms;
+allow shell hal_motor_hwservice:hwservice_manager find;
+binder_call(shell, hal_motor_default)
+
 ###
 ### Neverallow rules
 ###

--- a/public/xiaomi_motor.te
+++ b/public/xiaomi_motor.te
@@ -1,0 +1,3 @@
+# xm_takeback service
+type xiaomi_motor, domain;
+type xiaomi_motor_exec, exec_type, file_type;


### PR DESCRIPTION
This allows https://github.com/phhusson/platform_frameworks_av/commit/adceff7b6633b93606c09bf22a40aeedc8c6f701 to work under SELinux enforcing.
Also grants init and shell permission to run xiaomi-motor; untrusted apps are intentionally left out (potential security risk).